### PR TITLE
docs: refactor docstrings & README, improve type safety and command h…

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
       A small, simple, fully type-safe TypeScript library for defining and handling Discord slash commands and events, batteries included.
     </strong>
   </p>
+  <p>
+    <em>Inspired by <a href="https://github.com/discordx-ts/discordx">discordx</a></em>
+  </p>
 </div>
 
 ## 📖 Introduction
@@ -20,11 +23,25 @@
 - **Middleware-Style Guards**  
   Attach guard functions to commands for permissions, cooldowns, rate limits, or custom logic.  
 - **Concise Event Maps**  
-  Wire up any Discord.js event—`ready`, `messageCreate`, `guildMemberAdd`, etc.—in one place.  
+  Wire up any Discord.js event `ready`, `messageCreate`, `guildMemberAdd`, etc. in one place.  
 - **Auto-Registration**  
   Serialize and deploy your slash commands to the Discord API with a single async call.  
 - **One-Call Bootstrap**  
-  Spin up your entire bot—client, commands, events, registration—in one `createBot({ … })` invocation.
+  Spin up your entire bot-client, commands, events, registration-in one `createBot({ … })` invocation.
+
+## 🚧 Roadmap (Not Yet Implemented)
+
+1. ⚙️ **Autocomplete**  
+   We plan to add first-class support for Discord’s autocomplete right now you’ll need to handle it yourself.
+
+2. 🔄 **Partial Command Updates**  
+   Smartly patch only changed commands instead of full re-deploys.
+
+3. 🌐 **Command & Group Localizations**  
+   Multiple language support for names, descriptions, and choices.
+
+4. 🛠️ **Typed Interaction Contexts**  
+   Stronger, type-safe contexts for slash-command handlers.
 
 ## 🚀 Installation
 
@@ -53,6 +70,7 @@ import {
   option,
   guards,
   handleCommandInteraction,
+  initApplicationCommands,
   type GuardFn
 } from "disenchantment";
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -76,8 +76,7 @@ export interface SubcommandGroup<
 /**
  * Creates a top-level slash command definition.
  *
- * Accepts an optional set of typed options and guard functions. The resulting command
- * is displayed in Discord and executed when invoked by users.
+ * Accepts an optional set of typed options and guard functions.
  *
  * @example
  * ```ts

--- a/src/core.ts
+++ b/src/core.ts
@@ -27,6 +27,8 @@ export interface BotOptions {
    *     await interaction.reply("Pong!");
    *   },
    * });
+   *
+   * const someGroup = group("healthcheck", "check if bot is running", [pingCommand]);
    * ```
    */
   commands: CommandOrCommandGroup[];
@@ -97,7 +99,7 @@ export async function createBot({
 }
 
 /**
- * Registers your application's slash commands with Discord.
+ * Registers your application's slash commands.
  *
  * Use this after the bot is fully configured and the client is ready.
  * You can register globally or to specific guilds for faster propagation during development.

--- a/src/event.ts
+++ b/src/event.ts
@@ -10,7 +10,7 @@ export type EventHandler<TEvent extends keyof ClientEvents> = (
  *
  * Supports both `on` (repeat) and `once` (one-time) behaviors.
  *
- * @template TEvent - The name of the Discord.js event.
+ * @template TEvent - The name of the Discord.js event. (will be inherited from event name)
  */
 export interface SimpleEvent<TEvent extends keyof ClientEvents> {
   /**

--- a/src/group.ts
+++ b/src/group.ts
@@ -14,10 +14,15 @@ import type { NotEmptyString } from "./types.js";
  * ]);
  * ```
  *
+ * @example
+ * ```ts
+ * const nestedsubCommandGroup = group("admin", "General admin commands", [userAdminGroup]);
+ * ```
+ *
  * @param name - Group name (1–32 characters, lowercase).
  * @param description - Group description (max 100 characters).
  * @param commands - Array of subcommands or nested groups.
- * @returns A subcommand group definition.
+ * @returns A subcommand group definition or group of subcommands.
  */
 export const group = <
   TName extends string,

--- a/src/guard.ts
+++ b/src/guard.ts
@@ -8,7 +8,7 @@ import type { Client, CommandInteraction } from "discord.js";
  * a `next()` callback to hand off control, and a mutable `context` object.
  *
  * **Always bundle your guards with `guards(...)`** to preserve tuple typing and
- * ensure `ContextFromGuards<…>` correctly infers the combined context type.
+ * ensure the combined context type is correctly inferred.
  *
  * @template InteractionType
  *   The type of interaction you’re protecting (defaults to Discord’s `CommandInteraction`).
@@ -67,8 +67,6 @@ export type NextFn = () => Promise<void>;
  *
  * @example
  * ```ts
- * import { createCommand, guards } from 'your-bot-lib';
- *
  * // A simple logging guard
  * const logGuard: GuardFn = async (client, interaction, next) => {
  *   console.log(`User ${interaction.user.tag} ran ${interaction.commandName}`);
@@ -90,7 +88,7 @@ export type NextFn = () => Promise<void>;
  * // Use in your command
  * export const secret = createCommand({
  *   name: 'secret',
- *   description: 'An admin-only command with logging',
+ *   description: 'An admin only command with logging',
  *   guards: myGuards,
  *   handler: async (interaction) => {
  *     await interaction.reply('Shh… this is a secret.');

--- a/src/option.ts
+++ b/src/option.ts
@@ -82,10 +82,15 @@ export interface OptionInterface<
   D extends string = string,
   R extends boolean = boolean,
 > {
+  /** Option identifier (1–32 chars, lowercase) */
   name: NotEmptyString<N>;
+  /** Brief description (max. 100 chars) */
   description: NotEmptyString<D>;
+  /** Discord’s `ApplicationCommandOptionType` code */
   type: T;
+  /** Whether this option must be required by the user */
   required: R;
+  /** Type-specific constraints */
   extra?: OptionExtra<T>;
 }
 
@@ -109,13 +114,14 @@ type Option = <
  *   type: ApplicationCommandOptionType.String,
  *   required: true,
  *   extra: {
- *     maxLength: 200,
+ *     maxLength: 50,
  *   },
  * });
  * ```
  *
- * @param options - A fully typed option object with name, type, description, and constraints.
- * @returns The same object, with inferred types.
+ * @param options - A fully typed option object with name, type, description, requirement flag,
+ *                  and any additional constraints (`extra`).
+ * @returns The same object, with its types preserved for downstream inference.
  */
 export const option: Option = (options) => {
   return options;
@@ -125,7 +131,7 @@ type OptionTypeMap = {
   [ApplicationCommandOptionType.String]: string;
   [ApplicationCommandOptionType.Integer]: number;
   [ApplicationCommandOptionType.Boolean]: boolean;
-  [ApplicationCommandOptionType.User]: User;
+  [ApplicationCommandOptionType.User]: User | GuildMember;
   [ApplicationCommandOptionType.Channel]: Channel | VoiceChannel | TextChannel;
   [ApplicationCommandOptionType.Role]: Role;
   [ApplicationCommandOptionType.Mentionable]: User | Role | GuildMember;


### PR DESCRIPTION
…andling (#3)

* docs: clean up unnecessary docstring

* docs: added group example to commands docstring

* docs: update docstring to include detailed description

* docs: add comprehensive JSDoc to option module

* docs: clarified guards() usage and some minor text fixes

* docs: added example with nested group to docstring

* docs: fix broken example and added roadmap

* fix: added type that return from guild only commands