### PR TITLE
ci: removed ununsed branch from workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI Pipeline
 
 on:
   push:
-    branches: [ main, next ]
+    branches: [ main ]
   pull_request:
     branches: [ '*' ]
     paths-ignore:


### PR DESCRIPTION
This pull request updates the CI pipeline configuration to streamline branch handling. The most important change is the removal of the `next` branch from the list of branches triggering the pipeline on push events.

CI pipeline updates:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL5-R5): Modified the `push` event configuration to remove the `next` branch from triggering the CI pipeline, leaving only the `main` branch.