### PR TITLE
Add REST events support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,15 @@
 ## ⚙️ Features
 
 - **Object-based Slash Commands**  
-  Define commands & nested subcommands with plain TypeScript objects.  
+  Define commands & nested subcommands with plain TypeScript objects.
 - **Type-Safe Options**  
-  Leverage built-in helpers to declare option types, descriptions, defaults, and validations.  
+  Leverage built-in helpers to declare option types, descriptions, defaults, and validations.
 - **Middleware-Style Guards**  
-  Attach guard functions to commands for permissions, cooldowns, rate limits, or custom logic.  
+  Attach guard functions to commands for permissions, cooldowns, rate limits, or custom logic.
 - **Concise Event Maps**  
-  Wire up any Discord.js event `ready`, `messageCreate`, `guildMemberAdd`, etc. in one place.  
+  Wire up any Discord.js event `ready`, `messageCreate`, `guildMemberAdd`, etc. in one place.
 - **Auto-Registration**  
-  Serialize and deploy your slash commands to the Discord API with a single async call.  
+  Serialize and deploy your slash commands to the Discord API with a single async call.
 - **One-Call Bootstrap**  
   Spin up your entire bot-client, commands, events, registration-in one `createBot({ … })` invocation.
 
@@ -207,6 +207,15 @@ const mathGroup = group("math", "Mathematical operations", [addCommand], {
   },
 });
 
+// Define an event handler for rest event responses
+const responseEvent = createEvent({
+  event: "response",
+  emitter: "rest",
+  handler: async (_client, request, response) => {
+    console.log(`${request.method} ${request.path} ${response.status}`);
+  },
+});
+
 // Define an event handler for interactions
 const interactionCreateEvent = createEvent({
   event: "interactionCreate",
@@ -247,12 +256,11 @@ const readyEvent = createEvent({
 
 ## ✍️ Contributing
 
-1. Fork the repo & create a feature branch.  
-2. Write clear, focused commits—one logical change per commit.  
-3. Open a pull request with a description of what you’ve changed and why.  
+1. Fork the repo & create a feature branch.
+2. Write clear, focused commits—one logical change per commit.
+3. Open a pull request with a description of what you’ve changed and why.
 4. Ensure all existing tests pass and add tests for new features.
 
 ## 📜 License
 
 Distributed under the **MIT** License. See [`LICENSE`](./LICENSE) for details.
-

--- a/bun.lock
+++ b/bun.lock
@@ -1,12 +1,14 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "disenchantment",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
-        "@types/bun": "^1.2.11",
-        "discord.js": "^14.19.2",
+        "@types/bun": "^1.2.13",
+        "bun-types": "^1.3.13",
+        "discord.js": "^14.19.3",
         "tsup": "^8.4.0",
         "typescript": "^5.8.3",
       },
@@ -159,7 +161,7 @@
 
     "@sapphire/snowflake": ["@sapphire/snowflake@3.5.3", "", {}, "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ=="],
 
-    "@types/bun": ["@types/bun@1.2.13", "", { "dependencies": { "bun-types": "1.2.13" } }, "sha512-u6vXep/i9VBxoJl3GjZsl/BFIsvML8DfVDO0RYLEwtSZSp981kEO1V5NwRcO1CPJ7AmvpbnDCiMKo3JvbDEjAg=="],
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@types/estree": ["@types/estree@1.0.7", "", {}, "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="],
 
@@ -179,7 +181,7 @@
 
     "brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
 
-    "bun-types": ["bun-types@1.2.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-rRjA1T6n7wto4gxhAO/ErZEtOXyEZEmnIHQfl0Dt1QQSB4QV0iP6BZ9/YB5fZaHFQ2dwHFrmPaRQ9GGMX01k9Q=="],
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@types/bun": "^1.2.13",
+    "bun-types": "^1.3.13",
     "discord.js": "^14.19.3",
     "tsup": "^8.4.0",
     "typescript": "^5.8.3"

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,7 +1,7 @@
 import { Client, type ClientOptions } from "discord.js";
 import type { CommandOrCommandGroup } from "./command.js";
 import type { SimpleEvent } from "./event.js";
-import { bindClientEventHandlers } from "./handlers.js";
+import { bindEventHandlers } from "./handlers.js";
 import { MetadataStorage } from "./metadata-storage.js";
 import {
   flattenCommandTree,
@@ -90,7 +90,7 @@ export async function createBot({
   const slashCommands = serializeCommandsForAPI(commands);
   const eventMap = createEventHandlerMap(events);
 
-  bindClientEventHandlers(client, eventMap);
+  bindEventHandlers(client, eventMap);
 
   MetadataStorage.instance.setSimpleCommandMap(commandMap);
   MetadataStorage.instance.setCommandJsonBodies(slashCommands);

--- a/src/event.ts
+++ b/src/event.ts
@@ -40,7 +40,9 @@ export interface SimpleEvent<TEvent extends keyof Events> {
 /**
  * Creates a typed event listener for use with your bot configuration.
  *
- * @example
+ * Supports both `ClientEvents` (default) and `RestEvents` via the `emitter` parameter.
+ *
+ * @example Client event:
  * ```ts
  * const onReady = createEvent({
  *   event: "ready",
@@ -50,7 +52,23 @@ export interface SimpleEvent<TEvent extends keyof Events> {
  * });
  * ```
  *
- * @param config - The event definition, including the name and handler.
+ * @example REST event:
+ * ```ts
+ * const onResponse = createEvent({
+ *   event: "response",
+ *   emitter: "rest",
+ *   handler: async (_client, req, res) => {
+ *     console.log(`${req.method} ${req.path} ${res.status}`);
+ *   },
+ * });
+ * ```
+ *
+ * @param event - The name of the event to listen for.
+ * @param handler - The asynchronous handler function to run when the event is emitted.
+ * @param once - If true, the handler will be invoked only once.
+ * @param emitter - The emitter to listen on. Use `"rest"` for {@link RestEvents}
+ * such as `response`, `rateLimited`, `restDebug`, `invalidRequestWarning`,
+ * `hashSweep`, `handlerSweep`. Defaults to `"client"` for {@link ClientEvents}
  * @returns A typed event object.
  */
 export const createEvent = <TEvent extends keyof Events>(

--- a/src/event.ts
+++ b/src/event.ts
@@ -1,5 +1,4 @@
 import type { Client, ClientEvents, RestEvents } from "discord.js";
-import type { Emitter } from "./types";
 
 export type Events = ClientEvents & RestEvents;
 
@@ -30,17 +29,10 @@ export interface SimpleEvent<TEvent extends keyof Events> {
    * The asynchronous handler function to run when the event is emitted.
    */
   handler: EventHandler<TEvent>;
-  /**
-   * The emitter to listen on. Defaults to `"client"`.
-   * Use `"rest"` for REST events such as `response`, `rateLimited`, etc.
-   */
-  emitter?: Emitter;
 }
 
 /**
  * Creates a typed event listener for use with your bot configuration.
- *
- * Supports both `ClientEvents` (default) and `RestEvents` via the `emitter` parameter.
  *
  * @example Client event:
  * ```ts
@@ -56,7 +48,6 @@ export interface SimpleEvent<TEvent extends keyof Events> {
  * ```ts
  * const onResponse = createEvent({
  *   event: "response",
- *   emitter: "rest",
  *   handler: async (_client, req, res) => {
  *     console.log(`${req.method} ${req.path} ${res.status}`);
  *   },
@@ -66,9 +57,6 @@ export interface SimpleEvent<TEvent extends keyof Events> {
  * @param event - The name of the event to listen for.
  * @param handler - The asynchronous handler function to run when the event is emitted.
  * @param once - If true, the handler will be invoked only once.
- * @param emitter - The emitter to listen on. Use `"rest"` for {@link RestEvents}
- * such as `response`, `rateLimited`, `restDebug`, `invalidRequestWarning`,
- * `hashSweep`, `handlerSweep`. Defaults to `"client"` for {@link ClientEvents}
  * @returns A typed event object.
  */
 export const createEvent = <TEvent extends keyof Events>(

--- a/src/event.ts
+++ b/src/event.ts
@@ -1,8 +1,11 @@
-import type { Client, ClientEvents } from "discord.js";
+import type { Client, ClientEvents, RestEvents } from "discord.js";
+import type { Emitter } from "./types";
 
-export type EventHandler<TEvent extends keyof ClientEvents> = (
+export type Events = ClientEvents & RestEvents;
+
+export type EventHandler<TEvent extends keyof Events> = (
   client: Client,
-  ...args: ClientEvents[TEvent]
+  ...args: Events[TEvent]
 ) => Promise<void>;
 
 /**
@@ -12,7 +15,7 @@ export type EventHandler<TEvent extends keyof ClientEvents> = (
  *
  * @template TEvent - The name of the Discord.js event. (will be inherited from event name)
  */
-export interface SimpleEvent<TEvent extends keyof ClientEvents> {
+export interface SimpleEvent<TEvent extends keyof Events> {
   /**
    * If true, the handler will be invoked only once.
    */
@@ -27,6 +30,11 @@ export interface SimpleEvent<TEvent extends keyof ClientEvents> {
    * The asynchronous handler function to run when the event is emitted.
    */
   handler: EventHandler<TEvent>;
+  /**
+   * The emitter to listen on. Defaults to `"client"`.
+   * Use `"rest"` for REST events such as `response`, `rateLimited`, etc.
+   */
+  emitter?: Emitter;
 }
 
 /**
@@ -45,7 +53,7 @@ export interface SimpleEvent<TEvent extends keyof ClientEvents> {
  * @param config - The event definition, including the name and handler.
  * @returns A typed event object.
  */
-export const createEvent = <TEvent extends keyof ClientEvents>(
+export const createEvent = <TEvent extends keyof Events>(
   config: SimpleEvent<TEvent>,
 ): SimpleEvent<TEvent> => {
   return config;

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -104,7 +104,7 @@ export const handleCommandInteraction = async (
   );
 };
 
-export const bindClientEventHandlers = (
+export const bindEventHandlers = (
   client: Client,
   eventMap: EventHandlerMap,
 ): void => {

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -4,6 +4,7 @@ import {
   type Client,
   type ClientEvents,
   type InteractionContextType,
+  type RestEvents,
 } from "discord.js";
 import { composeGuards } from "./guard.js";
 import { MetadataStorage } from "./metadata-storage.js";
@@ -13,7 +14,7 @@ import type {
   OptionValue,
   ValidCommandOptions,
 } from "./option.js";
-import type { EventHanlderMap } from "./transformers/events.js";
+import type { EventHandlerMap } from "./transformers/events.js";
 
 const optionExtractors: Record<
   ValidCommandOptions,
@@ -105,9 +106,9 @@ export const handleCommandInteraction = async (
 
 export const bindClientEventHandlers = (
   client: Client,
-  eventMap: EventHanlderMap,
+  eventMap: EventHandlerMap,
 ): void => {
-  for (const [eventName, { on, once }] of eventMap) {
+  for (const [eventName, { on, once }] of eventMap.client) {
     for (const handler of on) {
       client.on(
         eventName,
@@ -120,6 +121,24 @@ export const bindClientEventHandlers = (
       client.once(
         eventName,
         async (...args: ClientEvents[typeof eventName]) =>
+          await handler(client, ...args),
+      );
+    }
+  }
+
+  for (const [eventName, { on, once }] of eventMap.rest) {
+    for (const handler of on) {
+      client.rest.on(
+        eventName,
+        async (...args: RestEvents[typeof eventName]) =>
+          await handler(client, ...args),
+      );
+    }
+
+    for (const handler of once) {
+      client.rest.once(
+        eventName,
+        async (...args: RestEvents[typeof eventName]) =>
           await handler(client, ...args),
       );
     }

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -14,7 +14,7 @@ import type {
   OptionValue,
   ValidCommandOptions,
 } from "./option.js";
-import type { EventHandlerMap } from "./transformers/events.js";
+import { isRestEvent, type EventHandlerMap } from "./transformers/events.js";
 
 const optionExtractors: Record<
   ValidCommandOptions,
@@ -108,39 +108,39 @@ export const bindClientEventHandlers = (
   client: Client,
   eventMap: EventHandlerMap,
 ): void => {
-  for (const [eventName, { on, once }] of eventMap.client) {
-    for (const handler of on) {
-      client.on(
-        eventName,
-        async (...args: ClientEvents[typeof eventName]) =>
-          await handler(client, ...args),
-      );
-    }
+  for (const [eventName, { on, once }] of eventMap) {
+    if (isRestEvent(eventName)) {
+      for (const handler of on) {
+        client.rest.on(
+          eventName,
+          async (...args: RestEvents[typeof eventName]) =>
+            await handler(client, ...args),
+        );
+      }
 
-    for (const handler of once) {
-      client.once(
-        eventName,
-        async (...args: ClientEvents[typeof eventName]) =>
-          await handler(client, ...args),
-      );
-    }
-  }
+      for (const handler of once) {
+        client.rest.once(
+          eventName,
+          async (...args: RestEvents[typeof eventName]) =>
+            await handler(client, ...args),
+        );
+      }
+    } else {
+      for (const handler of on) {
+        client.on(
+          eventName,
+          async (...args: ClientEvents[typeof eventName]) =>
+            await handler(client, ...args),
+        );
+      }
 
-  for (const [eventName, { on, once }] of eventMap.rest) {
-    for (const handler of on) {
-      client.rest.on(
-        eventName,
-        async (...args: RestEvents[typeof eventName]) =>
-          await handler(client, ...args),
-      );
-    }
-
-    for (const handler of once) {
-      client.rest.once(
-        eventName,
-        async (...args: RestEvents[typeof eventName]) =>
-          await handler(client, ...args),
-      );
+      for (const handler of once) {
+        client.once(
+          eventName,
+          async (...args: ClientEvents[typeof eventName]) =>
+            await handler(client, ...args),
+        );
+      }
     }
   }
 };

--- a/src/transformers/events.ts
+++ b/src/transformers/events.ts
@@ -1,36 +1,30 @@
-import type { ClientEvents, RestEvents } from "discord.js";
+import { RESTEvents, type ClientEvents, type RestEvents } from "discord.js";
 import type { EventHandler, SimpleEvent, Events } from "../event";
 
-export type ClientEventHandlerMap = Map<
-  keyof ClientEvents,
+export type EventHandlerMap = Map<
+  keyof ClientEvents | keyof RestEvents,
   {
-    once: EventHandler<keyof ClientEvents>[];
-    on: EventHandler<keyof ClientEvents>[];
+    once: EventHandler<keyof ClientEvents | keyof RestEvents>[];
+    on: EventHandler<keyof ClientEvents | keyof RestEvents>[];
   }
 >;
 
-export type RestEventHandlerMap = Map<
-  keyof RestEvents,
-  {
-    once: EventHandler<keyof RestEvents>[];
-    on: EventHandler<keyof RestEvents>[];
-  }
->;
-
-export type EventHandlerMap = {
-  client: ClientEventHandlerMap;
-  rest: RestEventHandlerMap;
+export const isRestEvent = (
+  event: keyof ClientEvents | keyof RestEvents,
+): event is keyof RestEvents => {
+  return Object.values(RESTEvents).some(
+    (re) => re === (event as keyof RestEvents),
+  );
 };
 
 export const createEventHandlerMap = (
   events: SimpleEvent<keyof Events>[],
 ): EventHandlerMap => {
-  const client: ClientEventHandlerMap = new Map();
-  const rest: RestEventHandlerMap = new Map();
+  const map: EventHandlerMap = new Map();
 
-  for (const { event, handler, once, emitter } of events) {
-    if (emitter === "rest") {
-      const record = rest.get(event as keyof RestEvents) || {
+  for (const { event, handler, once } of events) {
+    if (isRestEvent(event)) {
+      const record = map.get(event) || {
         once: [],
         on: [],
       };
@@ -41,9 +35,9 @@ export const createEventHandlerMap = (
         record.on.push(handler);
       }
 
-      rest.set(event as keyof RestEvents, record);
+      map.set(event, record);
     } else {
-      const record = client.get(event as keyof ClientEvents) || {
+      const record = map.get(event) || {
         once: [],
         on: [],
       };
@@ -54,9 +48,9 @@ export const createEventHandlerMap = (
         record.on.push(handler);
       }
 
-      client.set(event as keyof ClientEvents, record);
+      map.set(event, record);
     }
   }
 
-  return { client, rest };
+  return map;
 };

--- a/src/transformers/events.ts
+++ b/src/transformers/events.ts
@@ -1,7 +1,7 @@
-import type { ClientEvents } from "discord.js";
-import type { EventHandler, SimpleEvent } from "../event";
+import type { ClientEvents, RestEvents } from "discord.js";
+import type { EventHandler, SimpleEvent, Events } from "../event";
 
-export type EventHanlderMap = Map<
+export type ClientEventHandlerMap = Map<
   keyof ClientEvents,
   {
     once: EventHandler<keyof ClientEvents>[];
@@ -9,22 +9,54 @@ export type EventHanlderMap = Map<
   }
 >;
 
+export type RestEventHandlerMap = Map<
+  keyof RestEvents,
+  {
+    once: EventHandler<keyof RestEvents>[];
+    on: EventHandler<keyof RestEvents>[];
+  }
+>;
+
+export type EventHandlerMap = {
+  client: ClientEventHandlerMap;
+  rest: RestEventHandlerMap;
+};
+
 export const createEventHandlerMap = (
-  events: SimpleEvent<keyof ClientEvents>[],
-): EventHanlderMap => {
-  const map: EventHanlderMap = new Map();
+  events: SimpleEvent<keyof Events>[],
+): EventHandlerMap => {
+  const client: ClientEventHandlerMap = new Map();
+  const rest: RestEventHandlerMap = new Map();
 
-  for (const { event, handler, once } of events) {
-    const record = map.get(event) || { once: [], on: [] };
+  for (const { event, handler, once, emitter } of events) {
+    if (emitter === "rest") {
+      const record = rest.get(event as keyof RestEvents) || {
+        once: [],
+        on: [],
+      };
 
-    if (once) {
-      record.once.push(handler);
+      if (once) {
+        record.once.push(handler);
+      } else {
+        record.on.push(handler);
+      }
+
+      rest.set(event as keyof RestEvents, record);
     } else {
-      record.on.push(handler);
-    }
+      const record = client.get(event as keyof ClientEvents) || {
+        once: [],
+        on: [],
+      };
 
-    map.set(event, record);
+      if (once) {
+        record.once.push(handler);
+      } else {
+        record.on.push(handler);
+      }
+
+      client.set(event as keyof ClientEvents, record);
+    }
   }
 
-  return map;
+  return { client, rest };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,3 @@
 export type NotEmptyString<T extends string> = T extends ""
   ? "Error: String cannot be empty"
   : T;
-
-export type Emitter = "client" | "rest";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
 export type NotEmptyString<T extends string> = T extends ""
   ? "Error: String cannot be empty"
   : T;
+
+export type Emitter = "client" | "rest";

--- a/test/handlers.test.ts
+++ b/test/handlers.test.ts
@@ -322,10 +322,10 @@ describe("bindClientEventHandlers()", () => {
       },
     } as unknown as Client;
 
-    bindClientEventHandlers(
-      fakeClient,
-      new Map([["threadDelete", { on: [], once: [] }]]),
-    );
+    bindClientEventHandlers(fakeClient, {
+      client: new Map([["threadDelete", { on: [], once: [] }]]),
+      rest: new Map([["response", { on: [], once: [] }]]),
+    });
     expect(onCount).toBe(0);
     expect(onceCount).toBe(0);
   });

--- a/test/handlers.test.ts
+++ b/test/handlers.test.ts
@@ -11,7 +11,7 @@ import {
 import { createCommand } from "../src/command";
 import { GuardFn } from "../src/guard";
 import {
-  bindClientEventHandlers,
+  bindEventHandlers,
   buildCommandKey,
   extractCommandOptions,
   handleCommandInteraction,
@@ -279,7 +279,7 @@ describe("handleCommandInteraction()", () => {
   });
 });
 
-describe("bindClientEventHandlers()", () => {
+describe("bindEventHandlers()", () => {
   test("registers on and once handlers", () => {
     const recorded: string[] = [];
     const eventMap = new Map<string, { on: Function[]; once: Function[] }>([
@@ -299,7 +299,7 @@ describe("bindClientEventHandlers()", () => {
       once: (evt: string, fn: Function) => onceCalls.push({ evt, fn }),
     } as unknown as Client;
 
-    bindClientEventHandlers(fakeClient, eventMap as any);
+    bindEventHandlers(fakeClient, eventMap as any);
     expect(onCalls).toHaveLength(1);
     expect(onceCalls).toHaveLength(1);
     expect(onCalls[0].evt).toBe("E");
@@ -322,10 +322,10 @@ describe("bindClientEventHandlers()", () => {
       },
     } as unknown as Client;
 
-    bindClientEventHandlers(fakeClient, {
-      client: new Map([["threadDelete", { on: [], once: [] }]]),
-      rest: new Map([["response", { on: [], once: [] }]]),
-    });
+    bindEventHandlers(
+      fakeClient,
+      new Map([["threadDelete", { on: [], once: [] }]]),
+    );
     expect(onCount).toBe(0);
     expect(onceCount).toBe(0);
   });

--- a/test/transformers.test.ts
+++ b/test/transformers.test.ts
@@ -475,8 +475,7 @@ describe("createEventHandlerMap()", () => {
 
   test("returns an empty map for no events", () => {
     const map = createEventHandlerMap([]);
-    expect(map.client.size).toBe(0);
-    expect(map.rest.size).toBe(0);
+    expect(map.size).toBe(0);
   });
 
   test("collects 'on' handlers by default", () => {
@@ -486,13 +485,9 @@ describe("createEventHandlerMap()", () => {
       { event: "response", handler: handlerA },
       { event: "response", handler: handlerB },
     ]);
-    const client = map.client.get("ready")!;
+    const client = map.get("ready")!;
     expect(client.on).toEqual([handlerA, handlerB]);
     expect(client.once).toEqual([]);
-
-    const rest = map.rest.get("response")!;
-    expect(rest.on).toEqual([handlerA, handlerB]);
-    expect(rest.once).toEqual([]);
   });
 
   test("collects 'once' handlers when flagged", () => {
@@ -502,13 +497,9 @@ describe("createEventHandlerMap()", () => {
       { event: "response", handler: handlerA, once: true },
       { event: "response", handler: handlerB, once: true },
     ]);
-    const client = map.client.get("ready")!;
+    const client = map.get("ready")!;
     expect(client.once).toEqual([handlerA, handlerB]);
     expect(client.on).toEqual([]);
-
-    const rest = map.rest.get("response")!;
-    expect(rest.once).toEqual([handlerA, handlerB]);
-    expect(rest.on).toEqual([]);
   });
 
   test("aggregates mixed 'on' and 'once' handlers for the same event", () => {
@@ -522,12 +513,8 @@ describe("createEventHandlerMap()", () => {
       { event: "response", handler: handlerB },
       { event: "response", handler: handlerA, once: true },
     ]);
-    const client = map.client.get("ready")!;
+    const client = map.get("ready")!;
     expect(client.on).toEqual([handlerA, handlerB]);
     expect(client.once).toEqual([handlerB, handlerA]);
-
-    const rest = map.rest.get("response")!;
-    expect(rest.on).toEqual([handlerA, handlerB]);
-    expect(rest.once).toEqual([handlerB, handlerA]);
   });
 });

--- a/test/transformers.test.ts
+++ b/test/transformers.test.ts
@@ -475,27 +475,40 @@ describe("createEventHandlerMap()", () => {
 
   test("returns an empty map for no events", () => {
     const map = createEventHandlerMap([]);
-    expect(map.size).toBe(0);
+    expect(map.client.size).toBe(0);
+    expect(map.rest.size).toBe(0);
   });
 
   test("collects 'on' handlers by default", () => {
     const map = createEventHandlerMap([
       { event: "ready", handler: handlerA },
       { event: "ready", handler: handlerB },
+      { event: "response", handler: handlerA },
+      { event: "response", handler: handlerB },
     ]);
-    const rec = map.get("ready")!;
-    expect(rec.on).toEqual([handlerA, handlerB]);
-    expect(rec.once).toEqual([]);
+    const client = map.client.get("ready")!;
+    expect(client.on).toEqual([handlerA, handlerB]);
+    expect(client.once).toEqual([]);
+
+    const rest = map.rest.get("response")!;
+    expect(rest.on).toEqual([handlerA, handlerB]);
+    expect(rest.once).toEqual([]);
   });
 
   test("collects 'once' handlers when flagged", () => {
     const map = createEventHandlerMap([
       { event: "ready", handler: handlerA, once: true },
       { event: "ready", handler: handlerB, once: true },
+      { event: "response", handler: handlerA, once: true },
+      { event: "response", handler: handlerB, once: true },
     ]);
-    const rec = map.get("ready")!;
-    expect(rec.once).toEqual([handlerA, handlerB]);
-    expect(rec.on).toEqual([]);
+    const client = map.client.get("ready")!;
+    expect(client.once).toEqual([handlerA, handlerB]);
+    expect(client.on).toEqual([]);
+
+    const rest = map.rest.get("response")!;
+    expect(rest.once).toEqual([handlerA, handlerB]);
+    expect(rest.on).toEqual([]);
   });
 
   test("aggregates mixed 'on' and 'once' handlers for the same event", () => {
@@ -504,9 +517,17 @@ describe("createEventHandlerMap()", () => {
       { event: "ready", handler: handlerB, once: true },
       { event: "ready", handler: handlerB },
       { event: "ready", handler: handlerA, once: true },
+      { event: "response", handler: handlerA },
+      { event: "response", handler: handlerB, once: true },
+      { event: "response", handler: handlerB },
+      { event: "response", handler: handlerA, once: true },
     ]);
-    const rec = map.get("ready")!;
-    expect(rec.on).toEqual([handlerA, handlerB]);
-    expect(rec.once).toEqual([handlerB, handlerA]);
+    const client = map.client.get("ready")!;
+    expect(client.on).toEqual([handlerA, handlerB]);
+    expect(client.once).toEqual([handlerB, handlerA]);
+
+    const rest = map.rest.get("response")!;
+    expect(rest.on).toEqual([handlerA, handlerB]);
+    expect(rest.once).toEqual([handlerB, handlerA]);
   });
 });


### PR DESCRIPTION
This PR integrates REST events support alongside existing client events.

### Changes:
- Added `Emitter` type `client | rest` for `SimpleEvent` parameter, merged `ClientEvents` and `RestEvents` into a unified `Events` type and updated references accordingly. Extended JSDoc comments with parameter documentation and REST events usage example.
- Added `RestEventHandlerMap`, merged it with `ClientEventHandlerMap `into a unified `EventHandlerMap`, updated `createEventHandlerMap `to split client and rest handlers into separate maps with correct processing.
- Updated `bindClientEventHandlers` to correctly bind handlers for both `client` and `client.rest` emitters using the new split maps.
- Added `bun-types` dependency for correct `bun:test` support.
- Updated README with REST events documentation and usage examples.

### Tests:
- Updated `bindClientEventHandlers` tests to reflect new `client`/`rest` event map structure.
- Updated `createEventHandlerMap` tests to cover both client and rest handler maps including `on`/`once` combinations.